### PR TITLE
Fix hook: read from tool_response, add hooks.json for plugin auto-registration

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,7 @@
 {
   "name": "codex-skill",
-  "version": "1.0.0",
-  "description": "Give Claude Code a second opinion using OpenAI's Codex CLI",
-  "skills": ["skills/codex"]
+  "description": "Give Claude Code a second opinion using OpenAI Codex - automatic plan review via hooks",
+  "author": {
+    "name": "cathrynlavery"
+  }
 }

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Configure your OpenAI API key.
 
 | Model | Context | Speed | Best for |
 |-------|---------|-------|----------|
-| `gpt-5.4` | 272k | Standard | Most capable — deep analysis, architecture, novel problems |
+| `gpt-5.4` | 272k | Standard | Most capable -- deep analysis, architecture, novel problems |
 | `gpt-5.3-codex-spark` | 128k | Ultra-fast (1000+ tok/s) | Quick queries, fact checks (default) |
 | `gpt-5.3-codex` | 272k | Standard | General-purpose coding tasks |
 | `gpt-5.2-codex` | 272k | Standard | Older alternative |
@@ -39,9 +39,17 @@ Configure your OpenAI API key.
 
 ## Installation
 
-### 1. Install the skill
+### Option A: Install as Claude Code plugin (recommended)
 
-Clone and copy the skill to your Claude Code skills directory:
+```bash
+claude plugin add cathrynlavery/codex-skill
+```
+
+This auto-registers both the `/codex` skill and the automatic plan review hook. No manual configuration needed.
+
+### Option B: Manual installation
+
+#### 1. Install the skill
 
 ```bash
 git clone https://github.com/cathrynlavery/codex-skill.git
@@ -49,12 +57,13 @@ mkdir -p ~/.claude/skills/codex
 cp codex-skill/skills/codex/SKILL.md ~/.claude/skills/codex/
 ```
 
-### 2. Set up automatic plan review (recommended)
+#### 2. Set up automatic plan review
 
 Copy the hook script:
 
 ```bash
-cp hooks/plan-review.sh ~/.claude/hooks/
+mkdir -p ~/.claude/hooks
+cp codex-skill/hooks/plan-review.sh ~/.claude/hooks/
 chmod +x ~/.claude/hooks/plan-review.sh
 ```
 
@@ -79,22 +88,22 @@ Add to your `~/.claude/settings.json`:
 }
 ```
 
-Now every time Claude finishes a plan, Codex reviews it before you approve.
-
 ## How It Works
 
 ```
 ┌─────────────┐     ┌─────────────┐     ┌─────────────┐
-│   Claude    │────▶│ ExitPlanMode│────▶│   Codex     │
+│   Claude    │────>│ ExitPlanMode│────>│   Codex     │
 │ creates plan│     │   (hook)    │     │  reviews    │
 └─────────────┘     └─────────────┘     └─────────────┘
                                                │
-                                               ▼
+                                               v
                                         ┌─────────────┐
                                         │ You approve │
                                         │ with context│
                                         └─────────────┘
 ```
+
+The hook intercepts `ExitPlanMode` and reads the plan from `tool_response.plan` (the field where Claude Code stores the plan content). It passes the plan to Codex for review and displays the result before you approve.
 
 Codex reviews for:
 - Potential issues or risks
@@ -121,15 +130,21 @@ The skill uses `gpt-5.3-codex-spark` by default for speed. For complex questions
 
 ```
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-🔍 CODEX SECOND OPINION ON PLAN
+CODEX SECOND OPINION ON PLAN
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-✓ LGTM - Plan covers the main implementation steps.
+LGTM - Plan covers the main implementation steps.
 
 Minor suggestions:
-• Consider adding error handling for the API timeout case
-• Step 3 could be split into separate DB migration and code changes
+- Consider adding error handling for the API timeout case
+- Step 3 could be split into separate DB migration and code changes
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 ```
+
+## Troubleshooting
+
+**Hook doesn't fire:** Make sure Codex CLI is installed (`codex --version`) and on your PATH. The hook exits silently on errors to avoid blocking your workflow.
+
+**No plan content found:** The hook reads from `tool_response.plan` (primary) with fallbacks to `tool_response.filePath` and filesystem search. If you're seeing issues, check that you're using a current version of Claude Code.
 
 ## License
 

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -1,0 +1,17 @@
+{
+  "description": "Automatic plan review — sends Claude Code plans to Codex for a second opinion",
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "ExitPlanMode",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/plan-review.sh",
+            "timeout": 120
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/hooks/plan-review.sh
+++ b/hooks/plan-review.sh
@@ -1,26 +1,60 @@
 #!/bin/bash
 # Codex Plan Review Hook
 # Triggers when Claude exits plan mode to get a second opinion on the plan
+#
+# PostToolUse hook for ExitPlanMode. Receives JSON on stdin with:
+#   tool_input.plan          — plan content (direct)
+#   tool_input.planFilePath  — path to plan file on disk
+#   tool_response            — may contain plan content or file path
+#   cwd                      — working directory
 
 # Read hook input from stdin
 INPUT=$(cat)
 
-# Extract the plan file path from the tool input
-PLAN_FILE=$(echo "$INPUT" | jq -r '.tool_input.planFilePath // empty')
+PLAN_CONTENT=""
 
-# If no plan file in input, try to find it in the project
-if [ -z "$PLAN_FILE" ]; then
+# Strategy 1: Get plan content directly from tool_input.plan (fastest — no file I/O)
+PLAN_CONTENT=$(echo "$INPUT" | jq -r '.tool_input.plan // empty' 2>/dev/null)
+
+# Strategy 2: Read plan file from tool_input.planFilePath
+if [ -z "$PLAN_CONTENT" ]; then
+    PLAN_FILE=$(echo "$INPUT" | jq -r '.tool_input.planFilePath // empty' 2>/dev/null)
+    if [ -n "$PLAN_FILE" ] && [ -f "$PLAN_FILE" ]; then
+        PLAN_CONTENT=$(cat "$PLAN_FILE")
+    fi
+fi
+
+# Strategy 3: Try tool_response (may contain plan content or file path)
+if [ -z "$PLAN_CONTENT" ]; then
+    # tool_response might be a string with plan content
+    PLAN_CONTENT=$(echo "$INPUT" | jq -r 'if .tool_response | type == "string" then .tool_response else empty end' 2>/dev/null)
+fi
+
+if [ -z "$PLAN_CONTENT" ]; then
+    # tool_response might be an object with .plan or .filePath
+    PLAN_CONTENT=$(echo "$INPUT" | jq -r '.tool_response.plan // empty' 2>/dev/null)
+fi
+
+if [ -z "$PLAN_CONTENT" ]; then
+    PLAN_FILE=$(echo "$INPUT" | jq -r '.tool_response.filePath // empty' 2>/dev/null)
+    if [ -n "$PLAN_FILE" ] && [ -f "$PLAN_FILE" ]; then
+        PLAN_CONTENT=$(cat "$PLAN_FILE")
+    fi
+fi
+
+# Strategy 4: Search for PLAN.md in the project directory
+if [ -z "$PLAN_CONTENT" ]; then
     PROJECT_DIR=$(echo "$INPUT" | jq -r '.cwd // "."')
-    PLAN_FILE=$(find "$PROJECT_DIR" -name "PLAN.md" -o -name "plan.md" 2>/dev/null | head -1)
+    PLAN_FILE=$(find "$PROJECT_DIR" -maxdepth 2 -name "PLAN.md" -o -name "plan.md" 2>/dev/null | head -1)
+    if [ -n "$PLAN_FILE" ] && [ -f "$PLAN_FILE" ]; then
+        PLAN_CONTENT=$(cat "$PLAN_FILE")
+    fi
 fi
 
 # Exit silently if no plan found (non-blocking)
-if [ -z "$PLAN_FILE" ] || [ ! -f "$PLAN_FILE" ]; then
+if [ -z "$PLAN_CONTENT" ]; then
     exit 0
 fi
-
-# Read the plan content
-PLAN_CONTENT=$(cat "$PLAN_FILE")
 
 # Get Codex's review
 REVIEW=$(codex exec --dangerously-bypass-approvals-and-sandbox "You are reviewing a plan that Claude Code created. Analyze it for:
@@ -36,13 +70,18 @@ PLAN:
 $PLAN_CONTENT
 
 Respond with:
-- ✓ LGTM (if plan is solid)
-- OR specific concerns (bullet points, max 5)")
+- LGTM (if plan is solid)
+- OR specific concerns (bullet points, max 5)" 2>&1)
+
+# Exit silently if Codex fails (non-blocking)
+if [ $? -ne 0 ]; then
+    exit 0
+fi
 
 # Output the review as context for the user
 echo ""
 echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
-echo "🔍 CODEX SECOND OPINION ON PLAN"
+echo "CODEX SECOND OPINION ON PLAN"
 echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
 echo "$REVIEW"
 echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"

--- a/hooks/plan-review.sh
+++ b/hooks/plan-review.sh
@@ -6,7 +6,7 @@
 INPUT=$(cat)
 
 # Extract the plan file path from the tool input
-PLAN_FILE=$(echo "$INPUT" | jq -r '.tool_input.planFile // empty')
+PLAN_FILE=$(echo "$INPUT" | jq -r '.tool_input.planFilePath // empty')
 
 # If no plan file in input, try to find it in the project
 if [ -z "$PLAN_FILE" ]; then

--- a/hooks/plan-review.sh
+++ b/hooks/plan-review.sh
@@ -3,9 +3,10 @@
 # Triggers when Claude exits plan mode to get a second opinion on the plan
 #
 # PostToolUse hook for ExitPlanMode. Receives JSON on stdin with:
-#   tool_input.plan          — plan content (direct)
-#   tool_input.planFilePath  — path to plan file on disk
-#   tool_response            — may contain plan content or file path
+#   tool_response.plan       — plan content (direct string)
+#   tool_response.filePath   — path to plan file on disk
+#   tool_response.isAgent    — whether this is an agent plan
+#   tool_input               — typically empty object {}
 #   cwd                      — working directory
 
 # Read hook input from stdin
@@ -13,28 +14,11 @@ INPUT=$(cat)
 
 PLAN_CONTENT=""
 
-# Strategy 1: Get plan content directly from tool_input.plan (fastest — no file I/O)
-PLAN_CONTENT=$(echo "$INPUT" | jq -r '.tool_input.plan // empty' 2>/dev/null)
+# Strategy 1: Get plan content directly from tool_response.plan (primary — this is
+# where ExitPlanMode always puts the plan content)
+PLAN_CONTENT=$(echo "$INPUT" | jq -r '.tool_response.plan // empty' 2>/dev/null)
 
-# Strategy 2: Read plan file from tool_input.planFilePath
-if [ -z "$PLAN_CONTENT" ]; then
-    PLAN_FILE=$(echo "$INPUT" | jq -r '.tool_input.planFilePath // empty' 2>/dev/null)
-    if [ -n "$PLAN_FILE" ] && [ -f "$PLAN_FILE" ]; then
-        PLAN_CONTENT=$(cat "$PLAN_FILE")
-    fi
-fi
-
-# Strategy 3: Try tool_response (may contain plan content or file path)
-if [ -z "$PLAN_CONTENT" ]; then
-    # tool_response might be a string with plan content
-    PLAN_CONTENT=$(echo "$INPUT" | jq -r 'if .tool_response | type == "string" then .tool_response else empty end' 2>/dev/null)
-fi
-
-if [ -z "$PLAN_CONTENT" ]; then
-    # tool_response might be an object with .plan or .filePath
-    PLAN_CONTENT=$(echo "$INPUT" | jq -r '.tool_response.plan // empty' 2>/dev/null)
-fi
-
+# Strategy 2: Read plan file from tool_response.filePath
 if [ -z "$PLAN_CONTENT" ]; then
     PLAN_FILE=$(echo "$INPUT" | jq -r '.tool_response.filePath // empty' 2>/dev/null)
     if [ -n "$PLAN_FILE" ] && [ -f "$PLAN_FILE" ]; then
@@ -42,10 +26,27 @@ if [ -z "$PLAN_CONTENT" ]; then
     fi
 fi
 
-# Strategy 4: Search for PLAN.md in the project directory
+# Strategy 3: tool_response might be a plain string in some versions
+if [ -z "$PLAN_CONTENT" ]; then
+    PLAN_CONTENT=$(echo "$INPUT" | jq -r 'if .tool_response | type == "string" then .tool_response else empty end' 2>/dev/null)
+fi
+
+# Strategy 4: Try tool_input fields (fallback for future schema changes)
+if [ -z "$PLAN_CONTENT" ]; then
+    PLAN_CONTENT=$(echo "$INPUT" | jq -r '.tool_input.plan // empty' 2>/dev/null)
+fi
+
+if [ -z "$PLAN_CONTENT" ]; then
+    PLAN_FILE=$(echo "$INPUT" | jq -r '.tool_input.planFilePath // .tool_input.planFile // empty' 2>/dev/null)
+    if [ -n "$PLAN_FILE" ] && [ -f "$PLAN_FILE" ]; then
+        PLAN_CONTENT=$(cat "$PLAN_FILE")
+    fi
+fi
+
+# Strategy 5: Search for PLAN.md in the project directory
 if [ -z "$PLAN_CONTENT" ]; then
     PROJECT_DIR=$(echo "$INPUT" | jq -r '.cwd // "."')
-    PLAN_FILE=$(find "$PROJECT_DIR" -maxdepth 2 -name "PLAN.md" -o -name "plan.md" 2>/dev/null | head -1)
+    PLAN_FILE=$(find "$PROJECT_DIR" -maxdepth 2 \( -name "PLAN.md" -o -name "plan.md" \) 2>/dev/null | head -1)
     if [ -n "$PLAN_FILE" ] && [ -f "$PLAN_FILE" ]; then
         PLAN_CONTENT=$(cat "$PLAN_FILE")
     fi


### PR DESCRIPTION
## Summary

Three bugs prevented the plan-review hook from working:

1. **Wrong JSON field**: Hook read `tool_input.planFile` but ExitPlanMode puts the plan in `tool_response.plan` (tool_input is always `{}`)
2. **No hooks.json**: Plugin never auto-registered the hook — users had to manually edit settings.json
3. **Plugin manifest**: Had non-standard fields (`version`, `skills`) instead of auto-discovery

## What changed

### hooks/plan-review.sh
Reordered extraction strategies based on the actual ExitPlanMode JSON schema:

| # | Source | Status |
|---|--------|--------|
| 1 | `tool_response.plan` | **Primary** — always populated |
| 2 | `tool_response.filePath` | Backup — read from disk |
| 3 | `tool_response` (string) | Forward-compat |
| 4 | `tool_input.plan` / `.planFilePath` | Fallback for schema changes |
| 5 | Filesystem `PLAN.md` search | Last resort |

### hooks/hooks.json (new)
Auto-registers the PostToolUse:ExitPlanMode hook when installed as a Claude Code plugin. Uses `${CLAUDE_PLUGIN_ROOT}` so it works regardless of install path.

### .claude-plugin/plugin.json
Matches official plugin format (name, description, author). Removed `version` and `skills` fields — Claude Code uses directory auto-discovery.

### README.md
- Added `claude plugin add` install option
- Added troubleshooting section
- Fixed diagram encoding for terminal compatibility

## How I found it

Inspected the actual JSON that ExitPlanMode sends to PostToolUse hooks:

```json
{
  "tool_input": {},
  "tool_response": {
    "plan": "# The actual plan content...",
    "filePath": "/Users/.../.claude/plans/spicy-riding-melody.md",
    "isAgent": false
  }
}
```

The original hook read `tool_input.planFile` → empty → fell through to `find PLAN.md` → not found → silent exit. No Codex review ever ran.

## Test plan

- [x] Verified ExitPlanMode JSON schema from real session debug logs
- [x] Confirmed Strategy 1 (`tool_response.plan`) resolves content on first try
- [x] Confirmed Strategy 2 (`tool_response.filePath`) works when plan not inline
- [x] Confirmed Strategy 3 (`tool_response` as string) works for plain strings
- [x] Confirmed upstream hook silently fails with same input (zero output)
- [x] Confirmed plugin hook invocation via `${CLAUDE_PLUGIN_ROOT}` works
- [x] Validated hooks.json and plugin.json are valid JSON
- [x] Verified hook runs correctly under bash (shebang `#!/bin/bash`)